### PR TITLE
The day of the week is now also correct for all days of week 0

### DIFF
--- a/calpose/src/main/java/be/sigmadelta/calpose/Calpose.kt
+++ b/calpose/src/main/java/be/sigmadelta/calpose/Calpose.kt
@@ -131,14 +131,15 @@ fun CalposeWeek(
     widgets: CalposeWidgets
 ) {
     Row {
+        var dayOfWeekOrdinal = 1
         if (monthWeekNumber == 0) {
-            for (i in 0 until startDayOffSet) {
-                val priorDay = (priorMonthLength - (startDayOffSet - i - 1))
+            for (i in 1 .. startDayOffSet) {
+                val priorDay = (priorMonthLength - (startDayOffSet - i))
                 widgets.priorMonthDay(
                     this,
                     CalposeDate(
                         priorDay,
-                        month.minusMonths(1).atDay(priorDay).dayOfWeek,
+                        DayOfWeek.of(dayOfWeekOrdinal++),
                         month.minusMonths(1)
                     )
                 )
@@ -155,7 +156,7 @@ fun CalposeWeek(
             val day = if (monthWeekNumber == 0) i else (i + (7 * monthWeekNumber) - startDayOffSet)
             widgets.day(
                 this,
-                CalposeDate(day, DayOfWeek.of(i), month),
+                CalposeDate(day, DayOfWeek.of(dayOfWeekOrdinal++), month),
                 today
             )
         }
@@ -166,7 +167,7 @@ fun CalposeWeek(
                 widgets.nextMonthDay(
                     this, CalposeDate(
                         nextMonthDay,
-                        month.plusMonths(1).atDay(nextMonthDay).dayOfWeek,
+                        DayOfWeek.of(dayOfWeekOrdinal++),
                         month.plusMonths(1)
                     )
                 )


### PR DESCRIPTION
There was a bug that the day of the week was not always set correctly in the CalposeDate instance for the days of the first week of a month. The reason for this bug is that the days of the prior month were ignored while setting dayOfWeek for days of the current month.